### PR TITLE
fix: form submition on cancel button

### DIFF
--- a/components/Modals/CreateFormModal.tsx
+++ b/components/Modals/CreateFormModal.tsx
@@ -130,6 +130,7 @@ export const CreateFormModal: React.FC = () => {
             <Button
               disabled={loading}
               variant="outline"
+              type="button"
               onClick={createFormModal.closeCreateFormModal}
             >
               Cancel


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue #34  by fixing the unintended behavior in the "Create Form" modal. Previously, both the "Cancel" and "Continue" buttons were creating a form when the "Cancel" button was clicked. This PR ensures that the form is only created when the "Continue" button is clicked.

Fixes #34 
I fixed on cancel button form submition issue by adding type="button" property.

 Loom Video: [https://www.loom.com/share/d11dcaf9c35046c5afad816e5c91cd46](https://www.loom.com/share/d11dcaf9c35046c5afad816e5c91cd46)

## Requirement/Documentation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- No special testing configuration is required.
- Steps to test:
  1. Open the application.
  2. Navigate to the "Create Form" modal.
  3. Enter some data in the form fields.
  4. Click the "Cancel" button.
  5. Click the "Continue" button.

## Mandatory Tasks

- [x] Self-reviewed the code.
