### PR TITLE
fix: Add toast message for 'Create New' button when no project is selected

### DIFF
--- a/pages/__app/dashboard/[domain]/forms/index.tsx
+++ b/pages/__app/dashboard/[domain]/forms/index.tsx
@@ -1,13 +1,16 @@
 import type { NextPage } from 'next'
 import { PlusIcon } from 'lucide-react'
+import { toast } from 'react-hot-toast'
 
 import DashboardLayout from '@/layouts/DashboardLayout'
 import FormPane from '@/components/Dashboard/FormPane'
 import { IconButton } from '@/utils/IconButton'
 import { useCreateFormModal } from '@/store/useCreateFormModal'
+import { useSelectedProject } from '@/hooks/query/project'
 
 const DashboardFormPage: NextPage = () => {
   const createFormModal = useCreateFormModal()
+  const { project: selectedProject } = useSelectedProject()
 
   return (
     <DashboardLayout>
@@ -28,7 +31,15 @@ const DashboardFormPage: NextPage = () => {
               <div className="flex">
                 <IconButton
                   icon={PlusIcon}
-                  onClick={createFormModal.openCreateFormModal}
+                  onClick={() => {
+                    if (!selectedProject) {
+                      toast.error('Please select a project first.', {
+                        id: 'create-new-button',
+                      })
+                      return
+                    }
+                    createFormModal.openCreateFormModal()
+                  }}
                 >
                   Create new
                 </IconButton>


### PR DESCRIPTION
## What does this PR do?

This PR adds a toast message that says "Please select a project first" when you try to create a new form without selecting a project. It reminds users to pick a project before proceeding.

Fixes #29 

https://www.loom.com/share/6ac665cb48054a8186fa18828443b46d?sid=ee803553-3fde-4480-ae35-8d46c4bd9f76

## Requirement/Documentation

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Navigate to the dashboard using a fresh account.
- Click on the "Forms" tab.
- Attempt to create a new form.
- A toast message should appear, stating "Please select a project first."
- Next, create a project.
- Verify that the toast message no longer appears when attempting to create a new form.





## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.