### PR TITLE
feat: redirecting to Domain signin and signup page resolved

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,7 +17,7 @@ export function middleware(req: NextRequest) {
   const path = url.pathname
 
   if (!hostname) return
-  if(hostname==`${process.env.NEXT_PUBLIC_APP_DOMAIN}`){ 
+  if(hostname==`${process.env.NEXT_PUBLIC_APP_DOMAIN}` && (path=="/signin" || path=="/signup")){ 
     return NextResponse.redirect(`${url.protocol}//${process.env.NEXT_PUBLIC_APP_DASHBOARD_DOMAIN}.${process.env.NEXT_PUBLIC_APP_DOMAIN}${path}`);
   }
   

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,9 +17,8 @@ export function middleware(req: NextRequest) {
   const path = url.pathname
 
   if (!hostname) return
-
-  if(hostname==`${process.env.NEXT_PUBLIC_APP_DOMAIN}` && (path=="/signin" || path=="/signup")){ 
-    return NextResponse.redirect(`http://app.${process.env.NEXT_PUBLIC_APP_DOMAIN}${path}`);
+  if(hostname==`${process.env.NEXT_PUBLIC_APP_DOMAIN}`){ 
+    return NextResponse.redirect(`${url.protocol}//${process.env.NEXT_PUBLIC_APP_DASHBOARD_DOMAIN}.${process.env.NEXT_PUBLIC_APP_DOMAIN}${path}`);
   }
   
   const currentHost =

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,6 +18,10 @@ export function middleware(req: NextRequest) {
 
   if (!hostname) return
 
+  if(hostname==`${process.env.NEXT_PUBLIC_APP_DOMAIN}` && (path=="/signin" || path=="/signup")){ 
+    return NextResponse.redirect(`http://app.${process.env.NEXT_PUBLIC_APP_DOMAIN}${path}`);
+  }
+  
   const currentHost =
     process.env.NODE_ENV === 'production' && process.env.VERCEL === '1'
       ? hostname.replace(`.${process.env.NEXT_PUBLIC_APP_PUBLIC_DOMAIN}`, '')

--- a/pages/__app/signin.tsx
+++ b/pages/__app/signin.tsx
@@ -48,7 +48,7 @@ const SignInPage: NextPage = () => {
 
   useEffect(() => {
     if (user && user.id) {
-      router.replace('/')
+      router.replace('/dashboard')
     }
   }, [router, user])
 

--- a/pages/__app/signup.tsx
+++ b/pages/__app/signup.tsx
@@ -86,7 +86,7 @@ const SignUpPage: NextPage = () => {
   )
 
   useEffect(() => {
-    if (user && user.id) router.replace('/')
+    if (user && user.id) router.replace('/dashboard')
   }, [user, router])
 
   return (


### PR DESCRIPTION
## What does this PR do?

Fixes #70

if anyone visits localhost:3000/signin this redirects to app.localhost:3000/signin and same for signup page as well.

https://github.com/piyushgarg-dev/review-app/assets/77155890/7017552b-68f4-4d39-a84d-5ea37f9a4dcd



## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## How should this be tested?

- try to go to the domain pages localhost:3000/signin or localhost:3000/signup
- it redirects to the domain page  app.localhost:3000/signin or app.localhost:3000/signup respectively
