### PR TITLE
fix: Fixed the copy icon when clicked on it link is copied to clipboard when a form is created

### DIFF
--- a/components/Dashboard/FormPane.tsx
+++ b/components/Dashboard/FormPane.tsx
@@ -1,9 +1,9 @@
 import { Copy, Pencil, Share2, Trash2 } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
+import toast from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-import toast from 'react-hot-toast'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Tooltip,

--- a/components/Dashboard/FormPane.tsx
+++ b/components/Dashboard/FormPane.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-
+import toast from 'react-hot-toast'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Tooltip,
@@ -19,7 +19,6 @@ import {
   formatToLocalDateTime,
   getTimeDistance,
 } from '@/utils/time'
-import toast from 'react-hot-toast'
 
 const actionButtons = [
   {

--- a/components/Dashboard/FormPane.tsx
+++ b/components/Dashboard/FormPane.tsx
@@ -19,6 +19,7 @@ import {
   formatToLocalDateTime,
   getTimeDistance,
 } from '@/utils/time'
+import toast from 'react-hot-toast'
 
 const actionButtons = [
   {
@@ -43,16 +44,11 @@ const actionButtons = [
 const FormPane: React.FC = () => {
   const { project } = useSelectedProject()
   const { forms } = useListForms(project?.id)
-  const [copied, setCopied] = useState(false);
 
   const handleCopyClick = async (link:string) => {
     try {
       await navigator.clipboard.writeText(link);
-      setCopied(true);
-
-      setTimeout(() => {
-        setCopied(false)
-      }, 3000);
+     toast.success('Link Copied')
       
     } catch (error) {
       console.error('Failed to copy text: ', error);
@@ -132,10 +128,7 @@ const FormPane: React.FC = () => {
                       <Icon size={20} />
                     </TooltipTrigger>
                     <TooltipContent>
-                      
-                      {label.toLowerCase() === 'copy' && copied ? (
-                          <span className="text-green-500">Copied</span>
-                        ):<span>{label}</span>}
+                      <span>{label}</span>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>

--- a/components/Dashboard/FormPane.tsx
+++ b/components/Dashboard/FormPane.tsx
@@ -31,7 +31,7 @@ const actionButtons = [
   },
   {
     label: 'Copy',
-    icon: Copy,
+    icon: Copy
   },
   {
     label: 'Delete',
@@ -43,7 +43,21 @@ const actionButtons = [
 const FormPane: React.FC = () => {
   const { project } = useSelectedProject()
   const { forms } = useListForms(project?.id)
+  const [copied, setCopied] = useState(false);
 
+  const handleCopyClick = async (link:string) => {
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+
+      setTimeout(() => {
+        setCopied(false)
+      }, 3000);
+      
+    } catch (error) {
+      console.error('Failed to copy text: ', error);
+    }
+  };
   const router = useRouter()
 
   const [selectedRow, setSelectedRow] = useState(false)
@@ -108,7 +122,7 @@ const FormPane: React.FC = () => {
                           ? router.push(
                               `/dashboard/${project?.subdomain}/forms/edit/${form?.id}`
                             )
-                          : null
+                          :label.toLowerCase() === 'copy'?handleCopyClick(`http://localhost/${form?.slug}`):null
                       }
                       className={cn(
                         'offset_ring rounded-md p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800',
@@ -118,7 +132,10 @@ const FormPane: React.FC = () => {
                       <Icon size={20} />
                     </TooltipTrigger>
                     <TooltipContent>
-                      <span>{label}</span>
+                      
+                      {label.toLowerCase() === 'copy' && copied ? (
+                          <span className="text-green-500">Copied</span>
+                        ):<span>{label}</span>}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the bug where the link was not copied when the user clicks on the copy button. To reproduce this follow the steps given below in the "How should this be tested?" section.

Fixes #104

BEFORE

https://github.com/piyushgarg-dev/review-app/assets/131521505/cf4e8298-019c-4127-88cc-8e79334a3136

AFTER

https://github.com/piyushgarg-dev/review-app/assets/131521505/563d95e7-bad4-4d78-ac6b-5b1e0008aefa

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a project.
- Create a form.
- Click on 'Copy Icon'.
- Try to paste the link.
- See the error that link is not copied.

If you already have a form just go to http://app.localhost:3000/dashboard/subdomain/forms and see the issue.