### PR TITLE
fix: Add redirecting to SignIn page when accessing protected route with incorrect credentials

### DIFF
--- a/components/Dashboard/FormPane.tsx
+++ b/components/Dashboard/FormPane.tsx
@@ -43,7 +43,6 @@ const actionButtons = [
 const FormPane: React.FC = () => {
   const { project } = useSelectedProject()
   const { forms } = useListForms(project?.id)
-
   const router = useRouter()
 
   const [selectedRow, setSelectedRow] = useState(false)

--- a/components/ProtectedRoute.tsx
+++ b/components/ProtectedRoute.tsx
@@ -1,0 +1,31 @@
+import { useAuth } from '@/context/Authentication'
+import { useRouter } from 'next/router'
+import { useEffect, ReactNode } from 'react'
+
+interface ProtectedRouteProps {
+  children?: ReactNode
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    async function checkAuth() {
+      if (
+        router.pathname !== '/__app/signin' &&
+        router.pathname !== '/__app/signup' &&
+        isAuthenticated &&
+        !(await isAuthenticated())
+      ) {
+        router.push('/signin')
+      }
+    }
+
+    checkAuth()
+  }, [isAuthenticated, router])
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { Toaster } from 'react-hot-toast'
 import { AuthenticationProvider } from '@/context/Authentication'
 import '@/styles/globals.css'
 import ModalWrapper from '@/wrappers/ModalWrapper'
+import ProtectedRoute from '@/components/ProtectedRoute'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -37,9 +38,11 @@ export default function App({ Component, pageProps }: AppProps) {
             defaultTheme="system"
             enableSystem
           >
-            <ModalWrapper />
-            <Toaster position="top-right" />
-            <Component {...pageProps} />
+            <ProtectedRoute>
+              <ModalWrapper />
+              <Toaster position="top-right" />
+              <Component {...pageProps} />
+            </ProtectedRoute>
           </NextThemesProvider>
         </AuthenticationProvider>
         <ReactQueryDevtools />


### PR DESCRIPTION


## What does this PR do?

Right now, a user can access the dashboard and its child routes even when he/she is not logged in. This PR  makes it so that the user is redirected to the sign in page when he/she tries to access such protected routes when not logged in.


Fixes #102

Video Demonstration of Fix:
 https://www.loom.com/share/db79fbd897354415a80f8e11b8a83612?sid=7b0e9869-dee5-4d20-8da4-b87aef7cfe43


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

1. Logout if you are already logged in.
2. Try to access a protected route like: http://app.localhost:3000/dashboard
    You should now get redirected to the sign in page
3. Now login or sign up 
4. Now from the Application tab in the Dev tools, go to local storage and change the value of the authorization token to make it incorrect. This is to simulate the expiration of the authorization token.
5. Again try to access a protected route. You should be redirected to login page again, since you now have incorrect credentials




## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
