### PR TITLE
Auth fix: Redirect to signIn page when accessing routes without signi…

### DIFF
--- a/pages/__app/dashboard/[domain]/forms/edit/[formId].tsx
+++ b/pages/__app/dashboard/[domain]/forms/edit/[formId].tsx
@@ -2,6 +2,9 @@ import type { GetServerSideProps, NextPage } from 'next'
 
 import FormWrapper from '@/components/Dashboard/FormWrapper'
 import { useFormById } from '@/hooks/query/form'
+import { useCurrentUser } from '@/hooks/query/user'
+import { useEffect } from 'react'
+import router from 'next/router'
 
 interface PageProps {
   formId: string
@@ -9,7 +12,19 @@ interface PageProps {
 }
 
 const FormEditPage: NextPage<PageProps> = ({ formId, domain }) => {
+  const user = useCurrentUser()
+
+  useEffect(() => {
+    if (!user.user) {
+      router.push('/signin')
+    }
+  }, [router, user])
+
   const { form: reviewForm, isLoading } = useFormById(formId)
+
+  if (!user.user) {
+    return null
+  }
 
   if (isLoading) return <p>Loading....</p>
 

--- a/pages/__app/dashboard/[domain]/forms/index.tsx
+++ b/pages/__app/dashboard/[domain]/forms/index.tsx
@@ -7,10 +7,25 @@ import FormPane from '@/components/Dashboard/FormPane'
 import { IconButton } from '@/utils/IconButton'
 import { useCreateFormModal } from '@/store/useCreateFormModal'
 import { useSelectedProject } from '@/hooks/query/project'
+import { useCurrentUser } from '@/hooks/query/user'
+import { useEffect } from 'react'
+import router from 'next/router'
 
 const DashboardFormPage: NextPage = () => {
+  const user = useCurrentUser()
+
+  useEffect(() => {
+    if (!user.user) {
+      router.push('/signin')
+    }
+  }, [router, user])
+
   const createFormModal = useCreateFormModal()
   const { project: selectedProject } = useSelectedProject()
+
+  if (!user.user) {
+    return null
+  }
 
   return (
     <DashboardLayout>

--- a/pages/__app/dashboard/[domain]/index.tsx
+++ b/pages/__app/dashboard/[domain]/index.tsx
@@ -2,9 +2,24 @@ import type { NextPage } from 'next'
 
 import { useSelectedProject } from '@/hooks/query/project'
 import DashboardLayout from '@/layouts/DashboardLayout'
+import { useCurrentUser } from '@/hooks/query/user'
+import { useEffect } from 'react'
+import router from 'next/router'
 
 const DashboardMainPage: NextPage = () => {
+  const user = useCurrentUser()
+
+  useEffect(() => {
+    if (!user.user) {
+      router.push('/signin')
+    }
+  }, [router, user])
+
   const { project } = useSelectedProject()
+
+  if (!user.user) {
+    return null
+  }
 
   return (
     <DashboardLayout>

--- a/pages/__app/dashboard/index.tsx
+++ b/pages/__app/dashboard/index.tsx
@@ -4,11 +4,19 @@ import { useEffect, useMemo } from 'react'
 
 import { useSelectedProject, useUserProjects } from '@/hooks/query/project'
 import DashboardLayout from '@/layouts/DashboardLayout'
+import { useCurrentUser } from '@/hooks/query/user'
 
 const DashBoardPage: NextPage = () => {
   const router = useRouter()
+  const user = useCurrentUser()
   const { projects } = useUserProjects()
   const { project: selectedProject } = useSelectedProject()
+
+  useEffect(() => {
+    if (!user.user) {
+      router.push('/signin')
+    }
+  }, [router, user])
 
   const redirectToProject = useMemo(() => {
     if (!selectedProject) {
@@ -21,6 +29,10 @@ const DashBoardPage: NextPage = () => {
       router.push(`/dashboard/${redirectToProject.subdomain}`)
     }
   }, [redirectToProject, router])
+
+  if (!user.user) {
+    return null
+  }
 
   return (
     <DashboardLayout>


### PR DESCRIPTION
## What does this PR do?

If user is not signed in, we will redirect to them to Sign In page. Currently, anyone was able to access routes like /dashboard, /dashboard/undefined/forms, dashboard/undefined, etc.

Fixes #102

Here's a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/share/0e27cb4415b04f47a9b611978dde56b7

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

Currently, if you go to any below addresses, you can see a rendered page with just layout. Ofcourse, data is not populated. But, in this push, I've fixed this, and instead user is redirected to sign in first.

- /dashboard
- /dashboard/undefined
- /dashboard/undefined/forms
- /dashboard/undefined/forms/edit/{any_id}

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

