### PR TITLE
fix: Fixed the color on hovering links in the footer in both Light and Dark Mode

### DIFF
--- a/pages/templates/ebraj/index.tsx
+++ b/pages/templates/ebraj/index.tsx
@@ -473,7 +473,7 @@ export const Footer = () => {
                           <Link
                             href={singleSubItem.url}
                             key={index}
-                            className="block text-slate-500 hover:text-gray-100"
+                            className="block text-slate-500 dark:hover:text-gray-100 hover:text-gray-950"
                           >
                             <li key={index}>{singleSubItem.title}</li>
                           </Link>


### PR DESCRIPTION
## What does this PR do?
Fixes #195 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before on hovering Footer Links in LightMode -->
![Screenshot (277)](https://github.com/piyushgarg-dev/review-app/assets/45139653/a096e88d-2d2d-4bbe-9f2f-185da2cd5d98)

After fix -->
![Screenshot (276)](https://github.com/piyushgarg-dev/review-app/assets/45139653/2505691b-e215-4d15-92ad-b24e416c2181)


## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- No Documentation or Requirement

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Go to the homepage or any page that has Footer
- Hover on any link in the Footer in both dark and Light Mode

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


