### PR TITLE
fix: added cursor as pointer for theme toggle dropdown menu items

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -23,15 +23,24 @@ export function ThemeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="z-[1000]">
-        <DropdownMenuItem onClick={() => setTheme('light')}>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() => setTheme('light')}
+        >
           <span>Light</span>
           {theme === 'light' && <CheckIcon className="ml-auto mr-2 h-4 w-4" />}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')}>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() => setTheme('dark')}
+        >
           <span>Dark</span>
           {theme === 'dark' && <CheckIcon className="ml-auto mr-2 h-4 w-4" />}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')}>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() => setTheme('system')}
+        >
           <span>System</span>
           {theme === 'system' && <CheckIcon className="ml-auto mr-2 h-4 w-4" />}
         </DropdownMenuItem>


### PR DESCRIPTION
## What does this PR do?

Makes the cursor property as pointer for the theme toggle dropdown items, since they are clickable

Fixes #146 

## Video Demo
https://www.loom.com/share/b98640d571c2435090da6aeb864e6f79

## Type of change



- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Login or signup and go to dashboard.
2. On the upper righthand corner, click on the theme toggle button
3. Hover on the dropdown items of theme toggle button
4. You will see that the cursor is set to pointer
