### PR TITLE
made number of responses count dynamic

### DIFF
--- a/components/Dashboard/FormPane.tsx
+++ b/components/Dashboard/FormPane.tsx
@@ -12,7 +12,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { useListForms } from '@/hooks/query/form'
+import {useGetFormResponsesByProjectId, useListForms} from '@/hooks/query/form'
 import { useSelectedProject } from '@/hooks/query/project'
 import { cn } from '@/lib/utils'
 import {
@@ -44,6 +44,7 @@ const actionButtons = [
     color: 'text-red-500',
   },
 ]
+
 
 const FormPane: React.FC = () => {
   const { project } = useSelectedProject()
@@ -105,6 +106,17 @@ const FormPane: React.FC = () => {
     }
   }
 
+  const projectId = project?.id || ""
+  const { data: formResponses } = useGetFormResponsesByProjectId(projectId)
+  console.log (formResponses)
+
+  const getResponseCount = (formId: string) => {
+    if (formResponses && formResponses.pages[0].getFormResponsesByProjectId) {
+      return formResponses.pages[0].getFormResponsesByProjectId?.length;
+    }
+    return 0;
+  };
+
   return (
     <div className="mt-4 flex flex-col gap-1">
       {forms?.map((form, index) => (
@@ -140,7 +152,11 @@ const FormPane: React.FC = () => {
                   {form?.name}
                 </span>
                 <span className="flex items-center gap-1 truncate text-sm text-gray-500">
-                  0 responses. Created{' '}
+                  <Link href="/dashboard/web/testimonials" className="underline">
+                    {getResponseCount(form?.id || '')}{' '}
+                    {getResponseCount(form?.id || '') === 1 ? 'response' : 'responses'}.
+                  </Link>
+                  Created{' '}
                   {form?.createdAt && formatToLocalDateTime(form?.createdAt)}
                 </span>
               </p>


### PR DESCRIPTION
## What does this PR do?

Fixes issue #221 

Fixes #221 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/share/f733e00bf20f4c739a50053ec8e3e1ef?sid=806bab5e-766b-45f7-9c1e-16c854e879fd
-->

The fixed issue correctly displays the number of responses submitted to a particular form. 
Also, the number of forms has been underlined, referencing it as a link for easier navigation to see all the submitted response. Making the front-end experience more intuitive and easier to use. 

@hemantwasthere 


