### PR TITLE
fix: hover effect for project dropdown items

### DIFF
--- a/components/Dashboard/ProjectSwitch.tsx
+++ b/components/Dashboard/ProjectSwitch.tsx
@@ -62,7 +62,10 @@ const ProjectSwitch: React.FC = () => {
                   onSelect={() =>
                     project ? handleSelectProject(project?.subdomain) : null
                   }
-                  className="cursor-pointer text-sm"
+                  className={cn(
+                    'cursor-pointer text-sm',
+                    selectedProject?.id === project?.id && 'bg-accent'
+                  )}
                 >
                   <FolderOpenDot className="mr-2 h-4 w-4" />
                   {project?.name}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -115,7 +115,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}


### PR DESCRIPTION
## What does this PR do?

It makes it so that when not hovering over a project dropdown menu item, the hover effect is inactive, i.e. the background colour reverts to its original form, when cursor doesn't hover over an item.

Fixes #224

https://www.loom.com/share/db9aedd29a294192830cc488ce0dc6c8



## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Login / Signup into the app
2. Go to dashboard
3. Open the Project dropdown menu, which is located in the navbar at the top right
4. Hover over a project name (add projects if you have none) and see that their background colour changes (this won't work on the selected project, so make sure to test this on a not selected project)
5. Now, move the cursor outside of the dropdown, without it going through any other dropdown items
6. The dropdown item will revert to its original background colour since the cursor is not hovering over it.

