### PR TITLE
feat: added github workflow to greet contributors when an issue or PR …

### DIFF
--- a/.github/workflows/greet-contributors.yml
+++ b/.github/workflows/greet-contributors.yml
@@ -1,0 +1,26 @@
+name: Contributor Interaction
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  greet_contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: EddieHubCommunity/gh-action-community/src/welcome@main
+        if: ${{ github.event.sender.login != github.repository_owner }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            ### Hey @${{ github.actor }} 😃,
+
+            Thank you for raising an issue. Soon, the owner/maintainers will review it and offer feedback/suggestions.
+            Meanwhile if you enjoy contributing to the project, please consider giving it a star ⭐.
+          pr-message: |
+            ### Good work @${{ github.actor }} 😃,
+
+            Thank you for raising the PR. Soon, the owner/maintainers will review it and offer feedback/suggestions. 
+            Meanwhile if you enjoy contributing to the project, please consider giving it a star ⭐.


### PR DESCRIPTION

## What does this PR do?

This PR fixes the issue opened for a feature of greeting the contributors, during issue and PR opens.

Fixes #201 

## Requirement/Documentation

For this feature to work, few settings needs to be updated in the current repo, which is as follows 

1. Go to setting's of the repo
1. Under ***Actions*** tab go to general
2. In general go to ***workflow permissions*** and check mark the below option
     - [x]  Read and Write permissions.

Once this is completed, your repo will be ready for any new interactions from contributors.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

For testing this you can open an test issue and the greet-contributors workflow will be triggered and expected outcome of github bot comment can be noticed in the issue.

***Note : The owner of the repo can't do this testing, contributors can do it, since there is a check for owner in workflow, which when passes github bot comment won't be generated***
 
## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

#### Feel free to reach out through comments if you have any queries.

