### PR TITLE
fix: improve sidebar text contrast

### DIFF
--- a/components/Dashboard/DashboardSidebar/index.tsx
+++ b/components/Dashboard/DashboardSidebar/index.tsx
@@ -122,7 +122,7 @@ const DashboardSidebar: React.FC = () => {
           <ul className="px-3 py-2">
             {routes.map((route) => (
               <Fragment key={route.name}>
-                <p className="mt-7 px-2 text-xs font-bold tracking-wider text-primary/80 opacity-80">
+                <p className="mt-7 px-2 text-xs font-bold tracking-wider text-primary">
                   {route.name}
                 </p>
                 {route.links.map((link) => (


### PR DESCRIPTION

## What does this PR do?

- improves accessibility text contrast for headings of the side bar contents, in dark mode from `1.76` to `2.83`
- this is done because it was hard to see the sidebar heading in the dark mode

Fixes #242

## Before

![Screenshot 2023-10-23 at 11 03 59 AM](https://github.com/piyushgarg-dev/review-app/assets/108579856/691ce7bb-ba2c-466c-ad84-4074468ec971)

## After
  
<img width="451" alt="Screenshot 2023-10-23 at 11 28 49 AM" src="https://github.com/piyushgarg-dev/review-app/assets/108579856/06ae89f5-c16c-4ab3-a820-85c924a9245d">


## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Inspect and hover over the side bar headings and check the `Contrast` under accessibility section

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

