### PR TITLE
fix: increase padding in 404 page

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 const Custom404 = () => {
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
+    <div className="flex flex-col items-center justify-center h-screen p-6">
       <h1 className="text-3xl md:text-4xl font-semibold mb-4">404 - Page Not Found</h1>
       <p className="text-lg md:text-xl whitespace-wrap text-gray-600 mb-6">We apologize for the inconvenience. The page you are looking for does not exist or is under development.</p>
       <Link className="flex items-center text-blue-500 hover:text-blue-700" href="/dashboard">

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 const Custom404 = () => {
   return (
-    <div className="flex flex-col items-center justify-center h-screen p-6">
+    <div className="flex flex-col items-center justify-center h-screen px-3 text-center">
       <h1 className="text-3xl md:text-4xl font-semibold mb-4">404 - Page Not Found</h1>
       <p className="text-lg md:text-xl whitespace-wrap text-gray-600 mb-6">We apologize for the inconvenience. The page you are looking for does not exist or is under development.</p>
       <Link className="flex items-center text-blue-500 hover:text-blue-700" href="/dashboard">


### PR DESCRIPTION
there was no padding for left and right on the custom 404 page, so added some padding for the entire 404 page component

## What does this PR do?

- there was no padding for left and right on the custom 404 page, so added some padding for the entire 404 page component
- this improves user experience

Fixes #244

## Before

<img width="853" alt="Screenshot 2023-10-23 at 12 33 30 PM" src="https://github.com/piyushgarg-dev/review-app/assets/108579856/ad834ac7-df8d-41ce-9c05-5216a926a2b8">

## After


<img width="831" alt="Screenshot 2023-10-23 at 12 34 00 PM" src="https://github.com/piyushgarg-dev/review-app/assets/108579856/6852d503-3a20-4505-b6e4-cadc779e07e7">

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Go to `app.localhost:3000/random`
2. You'll get to a 404 page
3. Decrease the width of the page in `inspect` or view it in mobile mode
4. There must be left and right padding and everything should be clearly visible


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

