### PR TITLE
fix: changed 'Create new' to 'Create'

### DIFF
--- a/pages/__app/dashboard/[domain]/forms/index.tsx
+++ b/pages/__app/dashboard/[domain]/forms/index.tsx
@@ -41,7 +41,7 @@ const DashboardFormPage: NextPage = () => {
                     createFormModal.openCreateFormModal()
                   }}
                 >
-                  Create new
+                  Create
                 </IconButton>
               </div>
             </div>


### PR DESCRIPTION


## What does this PR do?

- Changes the create new form button to just 'Create', it fixes the button occupying 2 lines
- 'Create' implies the same meaning as 'Create new'

Fixes #246

 ## Before

<img width="803" alt="Screenshot 2023-10-23 at 1 28 08 PM" src="https://github.com/piyushgarg-dev/review-app/assets/108579856/3577d36f-bd5d-4291-aef6-369cee6a6d9c">

## After

<img width="791" alt="Screenshot 2023-10-23 at 1 28 35 PM" src="https://github.com/piyushgarg-dev/review-app/assets/108579856/2a939aaf-7546-40c3-8313-6407dbc9c412">


## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Go to `app.localhost:3000/dashboard`
2. Click on 'Forms' on the sidebar
3. Look at the `+ Create new` button
4. Decrease the width using inspect, you'll see the `Create` button instead of `Create new` button which will not spread to 2 lines

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
