### PR TITLE
feat: customized input UI component to support password visibility to…

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -33,9 +33,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           />
           <div className='flex items-center mx-2 cursor-pointer' onClick={() => { setPasswordVisibility(!passwordVisibility) }}>
             {passwordVisibility ? 
-            <Eye width={25} height={25} /> 
+            <Eye color="#c3c5ca" width={20} height={20} /> 
             : 
-            <EyeOff width={25} height={25} />}
+            <EyeOff color="#e5e7eb" width={20} height={20} />}
             </div>
         </div>
     )

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,22 +1,43 @@
 import * as React from 'react'
-
 import { cn } from '@/lib/utils'
-
+import {
+  Eye,
+  EyeOff
+} from 'lucide-react'
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement> { }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
+    const [passwordVisibility, setPasswordVisibility] = React.useState(false)
     return (
-      <input
-        type={type}
-        className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-all file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
+      type != "password" ?
+        <input
+          type={type}
+          className={cn(
+            'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-all file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+            className
+          )}
+          ref={ref}
+          {...props}
+        /> :
+        <div className='flex rounded-md border bg-background ring-offset-background transition-all focus-within:ring-2 focus-within:ring-ring focus-visible:ring-offset-2'>
+          <input
+            type={passwordVisibility ? "text" : "password"}
+            className={cn(
+              'flex h-10 w-full rounded-md bg-background px-3 py-2 text-smfile:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none',
+              className
+            )}
+            ref={ref}
+            {...props}
+          />
+          <div className='flex items-center mx-2 cursor-pointer' onClick={() => { setPasswordVisibility(!passwordVisibility) }}>
+            {passwordVisibility ? 
+            <Eye width={25} height={25} /> 
+            : 
+            <EyeOff width={25} height={25} />}
+            </div>
+        </div>
     )
   }
 )


### PR DESCRIPTION
## What does this PR do?
I customized the input UI component to support password visibility toggle feature in both LIGHT and DARK mode. So whenever we use input component and set type='password' we'll automatically get the input field with password visibility toggle feature.

Fixes #133 
Fixes #138

Loom Video
[Video](https://www.loom.com/share/887a5764771d4cb4b35162fd9c74d9cb?sid=c229711d-b47f-4f1f-8d8c-cff39c213fb3)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?
you can test this by trying to sign in or signup and try to toggle the password visibility

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

